### PR TITLE
Fix visualize accessor

### DIFF
--- a/cubed_xarray/cubedmanager.py
+++ b/cubed_xarray/cubedmanager.py
@@ -234,7 +234,7 @@ class DatasetAccessor:
     ):
         import cubed
 
-        cubed.visualize(
+        return cubed.visualize(
             *(self.ds[var].data for var in self.ds.data_vars.keys()),
             filename=filename,
             format=format,


### PR DESCRIPTION
Calling `ds.cubed.visualize()` in a notebook wasn't displaying the plan - this fixes it.